### PR TITLE
Mentions metadata

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1595,7 +1595,7 @@ class AsyncClient(Client):
                             ignore_unverified_devices=ignore_unverified_devices,
                         )
 
-                unencrypted_mentions = content.get("org.matrix.msc3952.mentions")
+                unencrypted_mentions = content.get("m.mentions") or content.get("org.matrix.msc3952.mentions")
 
                 # Reactions as of yet don't support encryption.
                 # Relevant spec proposal https://github.com/matrix-org/matrix-doc/pull/1849

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -223,6 +223,7 @@ from ..responses import (
 )
 from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
+import os
 
 _ShareGroupSessionT = Union[ShareGroupSessionError, ShareGroupSessionResponse]
 
@@ -1603,7 +1604,7 @@ class AsyncClient(Client):
                     # Encrypt our content and change the message type.
                     message_type, content = self.encrypt(room_id, message_type, content)
 
-                if unencrypted_mentions:
+                if os.environ.get("UNENCRYPTED_MENTIONS") and unencrypted_mentions:
                     content["unencrypted"] = { "m.mentions": unencrypted_mentions }
 
         method, path, data = Api.room_send(

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -23,7 +23,7 @@ from asyncio import Event as AsyncioEvent
 from dataclasses import dataclass, field
 from functools import partial, wraps
 from json.decoder import JSONDecodeError
-from pathlib import Path, pathlib
+import pathlib
 from typing import (
     Any,
     AsyncIterable,

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1604,7 +1604,7 @@ class AsyncClient(Client):
                     message_type, content = self.encrypt(room_id, message_type, content)
 
                 if unencrypted_mentions:
-                    content["unencrypted"] = { "org.matrix.msc3952.mentions": unencrypted_mentions }
+                    content["unencrypted"] = { "m.mentions": unencrypted_mentions }
 
         method, path, data = Api.room_send(
             self.access_token, room_id, message_type, content, uuid

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1595,11 +1595,16 @@ class AsyncClient(Client):
                             ignore_unverified_devices=ignore_unverified_devices,
                         )
 
+                unencrypted_mentions = content.get("org.matrix.msc3952.mentions")
+
                 # Reactions as of yet don't support encryption.
                 # Relevant spec proposal https://github.com/matrix-org/matrix-doc/pull/1849
                 if message_type != "m.reaction":
                     # Encrypt our content and change the message type.
                     message_type, content = self.encrypt(room_id, message_type, content)
+
+                if unencrypted_mentions:
+                    content["unencrypted"] = { "org.matrix.msc3952.mentions": unencrypted_mentions }
 
         method, path, data = Api.room_send(
             self.access_token, room_id, message_type, content, uuid

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -223,7 +223,6 @@ from ..responses import (
 )
 from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
-import os
 
 _ShareGroupSessionT = Union[ShareGroupSessionError, ShareGroupSessionResponse]
 
@@ -1596,7 +1595,7 @@ class AsyncClient(Client):
                             ignore_unverified_devices=ignore_unverified_devices,
                         )
 
-                unencrypted_mentions = content.get("m.mentions") or content.get("org.matrix.msc3952.mentions")
+                mentions_metadata = content.get("m.mentions") or content.get("org.matrix.msc3952.mentions")
 
                 # Reactions as of yet don't support encryption.
                 # Relevant spec proposal https://github.com/matrix-org/matrix-doc/pull/1849
@@ -1604,8 +1603,8 @@ class AsyncClient(Client):
                     # Encrypt our content and change the message type.
                     message_type, content = self.encrypt(room_id, message_type, content)
 
-                if os.environ.get("UNENCRYPTED_MENTIONS") and unencrypted_mentions:
-                    content["unencrypted"] = { "m.mentions": unencrypted_mentions }
+                if self.pan_conf.unencrypted_mentions and mentions_metadata:
+                    content["unencrypted"] = { "m.mentions": mentions_metadata }
 
         method, path, data = Api.room_send(
             self.access_token, room_id, message_type, content, uuid

--- a/nio/nio.conf
+++ b/nio/nio.conf
@@ -1,0 +1,2 @@
+[Default]
+UnencryptedMentions = False


### PR DESCRIPTION
If the event has mentions in the format specified on [org.matrix.msc3952.mentions](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3952-intentional-mentions.md#new-event-property), then mentions metadata is appended to the encrypted event.

See https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3952-intentional-mentions.md for additional context.